### PR TITLE
Expand init, switch, enable, and disable commands to update ancillary binaries

### DIFF
--- a/src/init_command.sh
+++ b/src/init_command.sh
@@ -9,12 +9,20 @@ help: |-
   - Creates files that allow the user update-alternatives settings to know which PHP binaries it should manage.
 ---
 local alternativesDir="${HOME}/.local/var/lib/alternatives"
-local alternativesFile="${alternativesDir}/php"
+local status=0
+local alternativesFile
+local type
 
-if [[ -f "${alternativesFile}" ]]; then
-    green "Your environment is already prepared!"
-else
-    if ! init_env; then
-        exit 1
+for type in php php-config phpize phar; do
+    alternativesFile="${alternativesDir}/${type}"
+    if [[ -f "${alternativesFile}" ]]; then
+        green "Alternative for ${type} binary is already prepared!"
+    elif ! init_env_for_type "${type}"; then
+        status=1
     fi
+done
+
+if [[ $status == 1 ]]; then
+    red "One or more errors when initializing the environment; please refer to the logs"
+    exit 1
 fi

--- a/src/lib/heredocs.sh
+++ b/src/lib/heredocs.sh
@@ -12,10 +12,34 @@ config_template() {
 EOF
 }
 
-alternatives_template() {
+alternatives_template_php() {
     /usr/bin/cat << EOF
 manual
 %s/.local/bin/php
+
+EOF
+}
+
+alternatives_template_php_config() {
+    /usr/bin/cat << EOF
+manual
+%s/.local/bin/php-config
+
+EOF
+}
+
+alternatives_template_phpize() {
+    /usr/bin/cat << EOF
+manual
+%s/.local/bin/phpize
+
+EOF
+}
+
+alternatives_template_phar() {
+    /usr/bin/cat << EOF
+manual
+%s/.local/bin/phar
 
 EOF
 }

--- a/src/lib/init_env.sh
+++ b/src/lib/init_env.sh
@@ -9,24 +9,14 @@
 ##   1 on failure
 #########################################
 init_env() {
-    local alternativesDir="${HOME}/.local/var/lib/alternatives"
-    local alternativesFile="${alternativesDir}/php"
-    local prompt
+    local status=0
+    local type
 
-    blue "Do you want to create the file ${alternativesFile} to handle your PHP versions?"
-    read -r prompt
-    if [[ "${prompt}" =~ ^[y|Y] ]]; then
-        if [[ ! -d "${alternativesDir}" ]]; then
-            mkdir -p "${alternativesDir}"
+    for type in php phpize php-config phar;do
+        if ! init_env_for_type "${type}"; then
+            status=1
         fi
+    done
 
-        # shellcheck disable=SC2059
-        printf "$(alternatives_template)" "${HOME}" > "${alternativesFile}"
-
-        green "Alternatives file created"
-        return 0
-    else
-        red "Aborting"
-        return 1
-    fi
+    return $status
 }

--- a/src/lib/init_env_for_type.sh
+++ b/src/lib/init_env_for_type.sh
@@ -1,0 +1,51 @@
+#########################################
+## Initialize the alternatives environment for a specific binary type
+##
+## Arguments:
+##   $1: Binary type (one of php, phpize, php-config, or phar)
+##
+## Outputs:
+##   Echoes status messages and prompts to STDOUT
+##
+## Status Codes:
+##   0 on success
+##   1 on failure
+#########################################
+init_env_for_type() {
+    local type=$1
+    local alternativesDir="${HOME}/.local/var/lib/alternatives"
+    local alternativesFile="${alternativesDir}/${type}"
+    local prompt
+
+    blue "Do you want to create the file ${alternativesFile} to handle your ${type} binary?"
+
+    read -r prompt
+    if [[ "${prompt}" =~ ^[y|Y] ]]; then
+        if [[ ! -d "${alternativesDir}" ]]; then
+            mkdir -p "${alternativesDir}"
+        fi
+
+        # shellcheck disable=SC2059
+        case $type in
+            php)
+                printf "$(alternatives_template_php)" "${HOME}" > "${alternativesFile}"
+                ;;
+            php-config)
+                printf "$(alternatives_template_php_config)" "${HOME}" > "${alternativesFile}"
+                ;;
+            phpize)
+                printf "$(alternatives_template_phpize)" "${HOME}" > "${alternativesFile}"
+                ;;
+            phar)
+                printf "$(alternatives_template_phar)" "${HOME}" > "${alternativesFile}"
+                ;;
+        esac
+
+        green "Alternatives file created for ${type} binary"
+        return 0
+    else
+        red "Aborting"
+        return 1
+    fi
+}
+

--- a/src/lib/is_env_initialized.sh
+++ b/src/lib/is_env_initialized.sh
@@ -10,5 +10,17 @@ is_env_initialized() {
         return 1;
     fi
 
+    if [[ ! -f "${HOME}/.local/var/lib/alternatives/php-config" ]]; then
+        return 1;
+    fi
+
+    if [[ ! -f "${HOME}/.local/var/lib/alternatives/phpize" ]]; then
+        return 1;
+    fi
+
+    if [[ ! -f "${HOME}/.local/var/lib/alternatives/phar" ]]; then
+        return 1;
+    fi
+
     return 0;
 }

--- a/src/lib/switch_phar.sh
+++ b/src/lib/switch_phar.sh
@@ -1,0 +1,23 @@
+#########################################
+## Switch the phar alternative
+##
+## Arguments:
+##   $1: PHP version
+##
+## Status Code:
+##   0 if successful
+##   1 if unsuccessful
+#########################################
+switch_phar() {
+    local command
+    local version=$1
+    command="$(alternatives_command)"
+
+    green "Switching phar binary to version ${version}"
+    if ! $command --set phar "/usr/bin/phar${version}"; then
+        red "Error switching phar binary version to ${version}!"
+        return 1
+    fi
+
+    return 0
+}

--- a/src/lib/switch_php.sh
+++ b/src/lib/switch_php.sh
@@ -1,0 +1,23 @@
+#########################################
+## Switch the PHP version alternative
+##
+## Arguments:
+##   $1: PHP version
+##
+## Status Code:
+##   0 if successful
+##   1 if unsuccessful
+#########################################
+switch_php() {
+    local command
+    local version=$1
+    command="$(alternatives_command)"
+
+    green "Switching PHP binary to version ${version}"
+    if ! $command --set php "/usr/bin/php${version}"; then
+        red "Error switching PHP binary version to ${version}!"
+        return 1
+    fi
+
+    return 0
+}

--- a/src/lib/switch_php_config.sh
+++ b/src/lib/switch_php_config.sh
@@ -1,0 +1,23 @@
+#########################################
+## Switch the php-config alternative
+##
+## Arguments:
+##   $1: PHP version
+##
+## Status Code:
+##   0 if successful
+##   1 if unsuccessful
+#########################################
+switch_php_config() {
+    local command
+    local version=$1
+    command="$(alternatives_command)"
+
+    green "Switching php-config binary to version ${version}"
+    if ! $command --set php-config "/usr/bin/php-config${version}"; then
+        red "Error switching php-config binary version to ${version}!"
+        return 1
+    fi
+
+    return 0
+}

--- a/src/lib/switch_phpize.sh
+++ b/src/lib/switch_phpize.sh
@@ -1,0 +1,23 @@
+#########################################
+## Switch the phpize alternative
+##
+## Arguments:
+##   $1: PHP version
+##
+## Status Code:
+##   0 if successful
+##   1 if unsuccessful
+#########################################
+switch_phpize() {
+    local command
+    local version=$1
+    command="$(alternatives_command)"
+
+    green "Switching phpize binary to version ${version}"
+    if ! $command --set phpize "/usr/bin/phpize${version}"; then
+        red "Error switching phpize binary version to ${version}!"
+        return 1
+    fi
+
+    return 0
+}

--- a/src/lib/version_enable.sh
+++ b/src/lib/version_enable.sh
@@ -13,16 +13,12 @@
 #########################################
 version_enable() {
     local version=$1
-    local alternativesFile="${HOME}/.local/var/lib/alternatives/php"
-    local binary="/usr/bin/php${version}"
     local priority="${version//./0}"
+    local alternativesFile
+    local binary
+    local template
 
     green "Enabling PHP version ${version}"
-
-    if [[ ! -f "${binary}" ]]; then
-        red "Unable to find binary for version ${version}; executable '${binary}' not found"
-        return 1
-    fi
 
     if ! is_env_initialized; then
         if ! init_env; then
@@ -30,13 +26,45 @@ version_enable() {
         fi
     fi
 
-    if grep -q "${binary}" "${alternativesFile}"; then
-        green "Binary already registered!"
-    else
-        file_trim_trailing_lines "${alternativesFile}"
-        printf "%s\n%s\n\n" "${binary}" "${priority}" >> "${alternativesFile}"
-        green "Done!"
-    fi
+    for type in php php-config phpize phar; do
+        alternativesFile="${HOME}/.local/var/lib/alternatives/${type}"
+        binary="/usr/bin/${type}${version}"
+
+        # shellcheck disable=SC2059
+        case $type in
+            php)
+                template="$(printf "$(alternatives_template_php)" "${HOME}")"
+                ;;
+            php-config)
+                template="$(printf "$(alternatives_template_php_config)" "${HOME}")"
+                ;;
+            phpize)
+                template="$(printf "$(alternatives_template_phpize)" "${HOME}")"
+                ;;
+            phar)
+                template="$(printf "$(alternatives_template_phar)" "${HOME}")"
+                ;;
+        esac
+
+        green "Enabling ${type} binary for PHP version ${version}"
+
+        if [[ ! -f "${binary}" ]]; then
+            red "Unable to find ${type} binary for version ${version}; executable '${binary}' not found"
+            return 1
+        fi
+
+        if grep -q "${binary}" "${alternativesFile}"; then
+            green "Binary already registered!"
+        else
+            file_trim_trailing_lines "${alternativesFile}"
+            if [[ "$(cat "${alternativesFile}")" == "${template}" ]]; then
+                printf "\n\n%s\n%s\n\n" "${binary}" "${priority}" >> "${alternativesFile}"
+            else
+                printf "%s\n%s\n\n" "${binary}" "${priority}" >> "${alternativesFile}"
+            fi
+            green "Done!"
+        fi
+    done
 
     return 0
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | no

### Description

Updates init, version enable, version disable, and switch commands to also update the alternatives for php-config, phpize, and phar.

This will ensure that when running PECL or using phpize to build extensions, they are built for the correct PHP version.
